### PR TITLE
Fix handling of multiple packets in a single read

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -67,13 +67,12 @@ class RNDC_Protocol extends EventEmitter {
 
 		socket.on('data', (data) => {
 			buffer = Buffer.concat([buffer, data]);
-			if (buffer.length >= 4) {
+			while (buffer.length >= 4) {
 				let len = buffer.readUInt32BE(0);
-				if (buffer.length >= 4 + len) {
-					let packet = buffer.slice(0, 4 + len);
-					handle_packet(packet);
-					buffer = buffer.slice(4 + len);
-				}
+				if (buffer.length < 4 + len) break;
+				let packet = buffer.slice(0, 4 + len);
+				handle_packet(packet);
+				buffer = buffer.slice(4 + len);
 			}
 		});
 


### PR DESCRIPTION
If multiple packets are read in a single read operation the library can fail to process all but the first packet. This wont yet work on normal bind until [issue 4416](https://gitlab.isc.org/isc-projects/bind9/-/issues/4416) in upstream bind9 is fixed.

Note that the nonce of a connection, once set, can never change, which is why having multiple commands inflight at the same time is fine from a protocol point of view.